### PR TITLE
Feature: set input box config(box size and box starting position) in cli 

### DIFF
--- a/src/ans/analysis.rs
+++ b/src/ans/analysis.rs
@@ -52,11 +52,7 @@ pub fn read_atoms_and_analysis<R: ?Sized>(input: &mut R, output: &str, on_data_l
             on_data_loaded(atoms_size);
             if config_simulation_box(&snapshot, box_config, verbose) {
                 // do analysis
-                do_analysis_wrapper(output,
-                                    box_config.box_size_.0,
-                                    box_config.box_size_.1,
-                                    box_config.box_size_.2,
-                                    &snapshot);
+                do_analysis_wrapper(output, box_config.box_size_, box_config.box_start, &snapshot);
             } else {
                 println!("config simulation box failed");
             }

--- a/src/ans/analysis.rs
+++ b/src/ans/analysis.rs
@@ -1,0 +1,30 @@
+use std::fs::File;
+use std::io::Read;
+use crate::ans::voronoy::voronoy_ans;
+use crate::ans::minio_input::voronoy_ans_minio;
+use crate::ans::libminio_rw;
+
+pub struct BoxConfig {
+    pub box_size: Vec<u64>,
+}
+
+// wrap function for calling voronoy_ans, select to read from
+// minio or local file system based in input config.
+pub fn voronoy_ans_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, box_config: &BoxConfig) {
+    if input_from_minio {
+        let (mut data, data_ptr) = voronoy_ans_minio(xyzfile);
+        if data.len() != 0 {
+            let on_data_loaded = |atoms_size: usize| {
+                unsafe {
+                    libminio_rw::ReleaseMinioFile(data_ptr);
+                };
+                println!("atom size is {}", atoms_size);
+            };
+            voronoy_ans(&mut data, output, on_data_loaded, box_config);
+        }
+    } else {
+        let mut input = File::open(xyzfile).unwrap(); // fixme: check file existence
+        fn on_file_data_read(atoms_size: usize) {}
+        voronoy_ans(&mut input.by_ref(), output, on_file_data_read, box_config);
+    }
+}

--- a/src/ans/analysis.rs
+++ b/src/ans/analysis.rs
@@ -1,16 +1,20 @@
+/**
+ * Created by genshen at 2020/12/25
+ */
 use std::fs::File;
 use std::io::Read;
-use crate::ans::voronoy::voronoy_ans;
+use std::io;
+use xyzio::Reader;
+
 use crate::ans::minio_input::voronoy_ans_minio;
 use crate::ans::libminio_rw;
+use crate::ans::box_config::{BoxConfig, config_simulation_box};
+use crate::ans::voronoy::do_analysis_wrapper;
 
-pub struct BoxConfig {
-    pub box_size: Vec<u64>,
-}
 
-// wrap function for calling voronoy_ans, select to read from
-// minio or local file system based in input config.
-pub fn voronoy_ans_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, box_config: &BoxConfig, verbose: bool) {
+// wrap function for calling read_atoms_and_analysis,
+// select to read from minio or local file system based in input config.
+pub fn analysis_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, box_config: &mut BoxConfig, verbose: bool) {
     if input_from_minio {
         let (mut data, data_ptr) = voronoy_ans_minio(xyzfile);
         if data.len() != 0 {
@@ -20,11 +24,42 @@ pub fn voronoy_ans_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, 
                 };
                 println!("atom size is {}", atoms_size);
             };
-            voronoy_ans(&mut data, output, on_data_loaded, box_config, verbose);
+            read_atoms_and_analysis(&mut data, output, on_data_loaded, box_config, verbose);
         }
     } else {
         let mut input = File::open(xyzfile).unwrap(); // fixme: check file existence
         fn on_file_data_read(atoms_size: usize) {}
-        voronoy_ans(&mut input.by_ref(), output, on_file_data_read, box_config, verbose);
+        read_atoms_and_analysis(&mut input.by_ref(), output, on_file_data_read, box_config, verbose);
+    }
+}
+
+// voronoy analysis method for BCC lattice and cube lattice.
+// todo: on data read error
+pub fn read_atoms_and_analysis<R: ?Sized>(input: &mut R, output: &str, on_data_loaded: impl Fn(usize),
+                                          box_config: &mut BoxConfig, verbose: bool)
+    where R: io::Read
+{
+    let mut reader = Reader::new(input);
+    // todo read atom one by one and compute its index lattice.
+    let snapshot_result = reader.read_snapshot();
+
+    match snapshot_result {
+        Err(e) => {
+            println!("read input xyz file error: {:?}", e);
+        }
+        Ok(mut snapshot) => {
+            let atoms_size = snapshot.size();
+            on_data_loaded(atoms_size);
+            if config_simulation_box(&snapshot, box_config, verbose) {
+                // do analysis
+                do_analysis_wrapper(output,
+                                    box_config.box_size_.0,
+                                    box_config.box_size_.1,
+                                    box_config.box_size_.2,
+                                    &snapshot);
+            } else {
+                println!("config simulation box failed");
+            }
+        }
     }
 }

--- a/src/ans/analysis.rs
+++ b/src/ans/analysis.rs
@@ -10,7 +10,7 @@ pub struct BoxConfig {
 
 // wrap function for calling voronoy_ans, select to read from
 // minio or local file system based in input config.
-pub fn voronoy_ans_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, box_config: &BoxConfig) {
+pub fn voronoy_ans_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, box_config: &BoxConfig, verbose: bool) {
     if input_from_minio {
         let (mut data, data_ptr) = voronoy_ans_minio(xyzfile);
         if data.len() != 0 {
@@ -20,11 +20,11 @@ pub fn voronoy_ans_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, 
                 };
                 println!("atom size is {}", atoms_size);
             };
-            voronoy_ans(&mut data, output, on_data_loaded, box_config);
+            voronoy_ans(&mut data, output, on_data_loaded, box_config, verbose);
         }
     } else {
         let mut input = File::open(xyzfile).unwrap(); // fixme: check file existence
         fn on_file_data_read(atoms_size: usize) {}
-        voronoy_ans(&mut input.by_ref(), output, on_file_data_read, box_config);
+        voronoy_ans(&mut input.by_ref(), output, on_file_data_read, box_config, verbose);
     }
 }

--- a/src/ans/box_config.rs
+++ b/src/ans/box_config.rs
@@ -5,7 +5,7 @@ use crate::ans::voronoy;
  */
 
 pub struct BoxConfig {
-    pub box_size: Vec<u64>,
+    pub input_box_size: Vec<u64>,
     // from input, length can be 0
     pub box_size_: (usize, usize, usize), // box size after determination
 }
@@ -19,7 +19,7 @@ pub fn config_simulation_box(snapshot: &xyzio::Snapshot, box_config: &mut BoxCon
     }
 
     // determine box size
-    if box_config.box_size.len() == 0 {
+    if box_config.input_box_size.len() == 0 {
         // automatically determine calculate box size via atoms position
         let size_dim = cube_root(atoms_size / 2);
         if size_dim != 0 { // it is a cube box
@@ -28,7 +28,7 @@ pub fn config_simulation_box(snapshot: &xyzio::Snapshot, box_config: &mut BoxCon
             box_config.box_size_ = auto_get_box_size(&snapshot.atoms);
         }
     } else {
-        box_config.box_size_ = (box_config.box_size[0] as usize, box_config.box_size[1] as usize, box_config.box_size[2] as usize);
+        box_config.box_size_ = (box_config.input_box_size[0] as usize, box_config.input_box_size[1] as usize, box_config.input_box_size[2] as usize);
     }
 
     // check box size

--- a/src/ans/box_config.rs
+++ b/src/ans/box_config.rs
@@ -84,9 +84,7 @@ fn auto_get_box_size(atoms: &Vec<xyzio::Atom>) -> (usize, usize, usize) {
         }
     }
 
-    let min_index = voronoy::voronoy(x_min, y_min, z_min);
-    let max_index = voronoy::voronoy(x_max, y_max, z_max);
-    let (size_x_, size_y_, size_z_) = (max_index.0 - min_index.0, max_index.1 - min_index.1, max_index.2 - min_index.2);
+    let (size_x_, size_y_, size_z_) = voronoy::voronoy(x_max - x_min, y_max - y_min, z_max - z_min);
     let mut sizes = (0, 0, 0);
 
     if size_x_ < 0 {

--- a/src/ans/box_config.rs
+++ b/src/ans/box_config.rs
@@ -1,0 +1,170 @@
+use crate::ans::voronoy;
+
+/**
+ * Created by genshen at 2020/12/25
+ */
+
+pub struct BoxConfig {
+    pub box_size: Vec<u64>,
+    // from input, length can be 0
+    pub box_size_: (usize, usize, usize), // box size after determination
+}
+
+// set simulation box config and return status: ture for setting ok, false for not ok.
+pub fn config_simulation_box(snapshot: &xyzio::Snapshot, box_config: &mut BoxConfig, verbose: bool) -> bool {
+    let atoms_size = snapshot.size();
+    if atoms_size % 2 != 0 { // due to feature of BCC lattice
+        println!("bad atoms size");
+        return false;
+    }
+
+    // determine box size
+    if box_config.box_size.len() == 0 {
+        // automatically determine calculate box size via atoms position
+        let size_dim = cube_root(atoms_size / 2);
+        if size_dim != 0 { // it is a cube box
+            box_config.box_size_ = (size_dim, size_dim, size_dim);
+        } else {
+            box_config.box_size_ = auto_get_box_size(&snapshot.atoms);
+        }
+    } else {
+        box_config.box_size_ = (box_config.box_size[0] as usize, box_config.box_size[1] as usize, box_config.box_size[2] as usize);
+    }
+
+    // check box size
+    let (box_size_x, box_size_y, box_size_z) = box_config.box_size_;
+    if box_size_x == 0 || box_size_y == 0 || box_size_z == 0 {
+        println!("bad box size");
+        return false;
+    }
+    if box_size_x * box_size_y * box_size_z != atoms_size {
+        println!("Warning: box size ({},{},{}) not match atoms size.", box_size_x, box_size_y, box_size_z);
+        return false;
+    }
+    if verbose {
+        println!("box size: [{},{},{}]", box_size_x, box_size_y, box_size_z);
+    }
+    return true;
+}
+
+// By passing the atoms position list,
+// then we can get the box size of simulation box, which can be used to calculating 1D lattice index.
+// If the box size in some dimension is not as desired, 0 will be return in the dimension.
+fn auto_get_box_size(atoms: &Vec<xyzio::Atom>) -> (usize, usize, usize) {
+    let mut x_min = f32::INFINITY; // todo can use f64 as float
+    let mut y_min = f32::INFINITY;
+    let mut z_min = f32::INFINITY;
+    let mut x_max = f32::NEG_INFINITY;
+    let mut y_max = f32::NEG_INFINITY;
+    let mut z_max = f32::NEG_INFINITY;
+    for i in 0..atoms.len() {
+        let x = atoms[i].x;
+        let y = atoms[i].y;
+        let z = atoms[i].z;
+
+        if x < x_min {
+            x_min = x;
+        }
+        if x > x_max {
+            x_max = x;
+        }
+
+        if y < y_min {
+            y_min = y;
+        }
+        if y > y_max {
+            y_max = y;
+        }
+
+        if z < z_min {
+            z_min = z;
+        }
+        if z > z_max {
+            z_max = z;
+        }
+    }
+
+    let min_index = voronoy::voronoy(x_min, y_min, z_min);
+    let max_index = voronoy::voronoy(x_max, y_max, z_max);
+    let (size_x_, size_y_, size_z_) = (max_index.0 - min_index.0, max_index.1 - min_index.1, max_index.2 - min_index.2);
+    let mut sizes = (0, 0, 0);
+
+    if size_x_ < 0 {
+        sizes.0 = 0;
+    } else {
+        sizes.0 = size_x_ as usize;
+    }
+    if size_y_ < 0 {
+        sizes.1 = 0;
+    } else {
+        sizes.1 = size_y_ as usize;
+    }
+
+    if size_z_ < 0 {
+        sizes.2 = 0;
+    } else {
+        sizes.2 = size_z_ as usize;
+    }
+    return sizes;
+}
+
+// return cube root of a positive integer number.
+fn cube_root(n: usize) -> usize {
+    let mut low = 1 as usize;
+    let mut high = n;
+    let mut mid = n;
+    while low <= high {
+        mid = (high + low) / 2;
+        if n < mid * mid * mid {
+            high = mid - 1;
+        } else if n == mid * mid * mid {
+            return mid;
+        } else {
+            low = mid + 1;
+        }
+    }
+    return 0;
+}
+
+#[cfg(test)]
+mod get_box_size_tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_get_box_size_1() {
+        let mut atoms = Vec::new();
+        atoms.push(xyzio::Atom {
+            element: String::from("Fe"),
+            x: 4.0 * voronoy::LATTICE_CONST,
+            y: 6.0 * voronoy::LATTICE_CONST,
+            z: 8.0 * voronoy::LATTICE_CONST,
+        });
+        atoms.push(xyzio::Atom {
+            element: String::from("Fe"),
+            x: 2.0 * voronoy::LATTICE_CONST,
+            y: 1.0 * voronoy::LATTICE_CONST,
+            z: 9.0 * voronoy::LATTICE_CONST,
+        });
+        // get lattice size in each dimension
+        let sizes = auto_get_box_size(&atoms);
+        assert_eq!(sizes.0, 2 * 2);
+        assert_eq!(sizes.1, 5);
+        assert_eq!(sizes.2, 1);
+    }
+}
+
+#[cfg(test)]
+mod cube_root_tests {
+    use super::*;
+
+    #[test]
+    fn test_cube_root() {
+        assert_eq!(cube_root(1), 1);
+        assert_eq!(cube_root(8), 2);
+        assert_eq!(cube_root(27), 3);
+        assert_eq!(cube_root(64), 4);
+        assert_eq!(cube_root(65), 0);
+        assert_eq!(cube_root(125), 5);
+    }
+}

--- a/src/ans/box_config.rs
+++ b/src/ans/box_config.rs
@@ -5,9 +5,11 @@ use crate::ans::voronoy;
  */
 
 pub struct BoxConfig {
+    pub input_box_start: Vec<voronoy::Float>,
     pub input_box_size: Vec<u64>,
     // from input, length can be 0
     pub box_size_: (usize, usize, usize), // box size after determination
+    pub box_start: (voronoy::Float, voronoy::Float, voronoy::Float), // start position of box
 }
 
 // set simulation box config and return status: ture for setting ok, false for not ok.
@@ -44,6 +46,15 @@ pub fn config_simulation_box(snapshot: &xyzio::Snapshot, box_config: &mut BoxCon
     if verbose {
         println!("box size: [{},{},{}]", box_size_x, box_size_y, box_size_z);
     }
+
+    // determine box starting position
+    if box_config.input_box_start.len() == 3 {
+        box_config.box_start = (box_config.input_box_start[0], box_config.input_box_start[1], box_config.input_box_start[2]);
+    } else {
+        // auto determine
+        box_config.box_start = (0.0, 0.0, 0.0);
+    }
+
     return true;
 }
 

--- a/src/ans/mod.rs
+++ b/src/ans/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod voronoy;
+pub(crate) mod analysis;
 mod libminio_rw;
 mod minio_input;

--- a/src/ans/mod.rs
+++ b/src/ans/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod voronoy;
 pub(crate) mod analysis;
+pub(crate) mod box_config;
 mod libminio_rw;
 mod minio_input;

--- a/src/ans/voronoy.rs
+++ b/src/ans/voronoy.rs
@@ -65,7 +65,8 @@ const D: Float = -3.0 / 4.0;
 
 // voronoy analysis method for BCC lattice and cube lattice.
 // todo: on data read error
-pub fn voronoy_ans<R: ?Sized>(input: &mut R, output: &str, on_data_loaded: impl Fn(usize), box_config: &BoxConfig)
+pub fn voronoy_ans<R: ?Sized>(input: &mut R, output: &str, on_data_loaded: impl Fn(usize),
+                              box_config: &BoxConfig, verbose: bool)
     where R: io::Read
 {
     let mut reader = Reader::new(input);
@@ -113,7 +114,10 @@ pub fn voronoy_ans<R: ?Sized>(input: &mut R, output: &str, on_data_loaded: impl 
             if box_size_x * box_size_y * box_size_z != atoms_size {
                 println!("Warning: box size ({},{},{}) not match atoms size.", box_size_x, box_size_y, box_size_z);
                 return;
-                }
+            }
+            if verbose {
+                println!("box size: [{},{},{}]", box_size_x, box_size_y, box_size_z);
+            }
             // do analysis
             do_analysis_wrapper(output, box_size_x, box_size_y, box_size_z, &snapshot);
         }

--- a/src/ans/voronoy.rs
+++ b/src/ans/voronoy.rs
@@ -1,17 +1,14 @@
-use std::{f32, io};
+use std::{f32};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::collections::BTreeMap;
-use xyzio::Reader;
 use std::error::Error;
-use crate::ans::analysis::BoxConfig;
-
 
 type Float = f32;
 type Inx = i32;
 
-const LATTICE_CONST: Float = 2.85532;
+pub const LATTICE_CONST: Float = 2.85532;
 
 /**
  * The coordinate offset of 8 minor lattices surrounding a major lattice.
@@ -63,68 +60,7 @@ const NORMAL_VECTOR: [(Float, Float, Float); 8] = [
 const D: Float = -3.0 / 4.0;
 
 
-// voronoy analysis method for BCC lattice and cube lattice.
-// todo: on data read error
-pub fn voronoy_ans<R: ?Sized>(input: &mut R, output: &str, on_data_loaded: impl Fn(usize),
-                              box_config: &BoxConfig, verbose: bool)
-    where R: io::Read
-{
-    let mut reader = Reader::new(input);
-    // todo read atom one by one and compute its index lattice.
-    let snapshot_result = reader.read_snapshot();
-
-    match snapshot_result {
-        Err(e) => {
-            println!("read input xyz file error: {:?}", e);
-        }
-        Ok(mut snapshot) => {
-            let atoms_size = snapshot.size();
-            on_data_loaded(atoms_size);
-            if atoms_size % 2 != 0 { // due to feature of BCC lattice
-                println!("bad atoms size");
-                return;
-            }
-
-            // determine box size
-            let (mut box_size_x, mut box_size_y, mut box_size_z) = (0, 0, 0);
-            if box_config.box_size.len() == 0 {
-                // automatically determine calculate box size via atoms position
-                let size_dim = cube_root(atoms_size / 2);
-                if size_dim != 0 { // it is a cube box
-                    box_size_x = size_dim;
-                    box_size_y = size_dim;
-                    box_size_z = size_dim;
-                } else {
-                    let (_size_x, _size_y, _size_z) = auto_get_box_size(&snapshot.atoms);
-                    box_size_x = _size_x;
-                    box_size_y = _size_y;
-                    box_size_z = _size_z;
-                }
-            } else {
-                box_size_x = box_config.box_size[0] as usize;
-                box_size_y = box_config.box_size[1] as usize;
-                box_size_z = box_config.box_size[2] as usize;
-            }
-
-            // check box size
-            if box_size_x == 0 || box_size_y == 0 || box_size_z == 0 {
-                println!("bad box size");
-                return;
-            }
-            if box_size_x * box_size_y * box_size_z != atoms_size {
-                println!("Warning: box size ({},{},{}) not match atoms size.", box_size_x, box_size_y, box_size_z);
-                return;
-            }
-            if verbose {
-                println!("box size: [{},{},{}]", box_size_x, box_size_y, box_size_z);
-            }
-            // do analysis
-            do_analysis_wrapper(output, box_size_x, box_size_y, box_size_z, &snapshot);
-        }
-    }
-}
-
-fn do_analysis_wrapper(output: &str, size_x: usize, size_y: usize, size_z: usize, mut snapshot: &xyzio::Snapshot) {
+pub fn do_analysis_wrapper(output: &str, size_x: usize, size_y: usize, size_z: usize, mut snapshot: &xyzio::Snapshot) {
     // prepare file
     let path = Path::new(output);
     let display = path.display();
@@ -137,67 +73,6 @@ fn do_analysis_wrapper(output: &str, size_x: usize, size_y: usize, size_z: usize
     let mut writer = BufWriter::new(file);
     do_analysis(&mut writer, size_x, size_y, size_z, &snapshot.atoms);
     writer.flush().unwrap();
-}
-
-// By passing the atoms position list,
-// then we can get the box size of simulation box, which can be used to calculating 1D lattice index.
-// If the box size in some dimension is not as desired, 0 will be return in the dimension.
-fn auto_get_box_size(atoms: &Vec<xyzio::Atom>) -> (usize, usize, usize) {
-    let mut x_min = f32::INFINITY; // todo can use f64 as float
-    let mut y_min = f32::INFINITY;
-    let mut z_min = f32::INFINITY;
-    let mut x_max = f32::NEG_INFINITY;
-    let mut y_max = f32::NEG_INFINITY;
-    let mut z_max = f32::NEG_INFINITY;
-    for i in 0..atoms.len() {
-        let x = atoms[i].x;
-        let y = atoms[i].y;
-        let z = atoms[i].z;
-
-        if x < x_min {
-            x_min = x;
-        }
-        if x > x_max {
-            x_max = x;
-        }
-
-        if y < y_min {
-            y_min = y;
-        }
-        if y > y_max {
-            y_max = y;
-        }
-
-        if z < z_min {
-            z_min = z;
-        }
-        if z > z_max {
-            z_max = z;
-        }
-    }
-
-    let min_index = voronoy(x_min, y_min, z_min);
-    let max_index = voronoy(x_max, y_max, z_max);
-    let (size_x_, size_y_, size_z_) = (max_index.0 - min_index.0, max_index.1 - min_index.1, max_index.2 - min_index.2);
-    let mut sizes = (0, 0, 0);
-
-    if size_x_ < 0 {
-        sizes.0 = 0;
-    } else {
-        sizes.0 = size_x_ as usize;
-    }
-    if size_y_ < 0 {
-        sizes.1 = 0;
-    } else {
-        sizes.1 = size_y_ as usize;
-    }
-
-    if size_z_ < 0 {
-        sizes.2 = 0;
-    } else {
-        sizes.2 = size_z_ as usize;
-    }
-    return sizes;
 }
 
 // in do_analysis, calculate atom's occupation by box size and its lattice index,
@@ -244,7 +119,7 @@ fn do_analysis(writer: &mut BufWriter<File>, box_x_size: usize, box_y_size: usiz
  * calculate coordinate of nearest lattice for a atom:
  * X,Y,Z is the position of atom.
  */
-fn voronoy(x: Float, y: Float, z: Float) -> (Inx, Inx, Inx) {
+pub fn voronoy(x: Float, y: Float, z: Float) -> (Inx, Inx, Inx) {
     let lat_coord_x = (x / LATTICE_CONST).round() as Inx;
     let mut lat_coord_y = (y / LATTICE_CONST).round() as Inx;
     let mut lat_coord_z = (z / LATTICE_CONST).round() as Inx;
@@ -270,51 +145,6 @@ fn voronoy(x: Float, y: Float, z: Float) -> (Inx, Inx, Inx) {
     return (lat_coord_x, lat_coord_y, lat_coord_z);
 }
 
-// return cube root of a positive integer number.
-fn cube_root(n: usize) -> usize {
-    let mut low = 1 as usize;
-    let mut high = n;
-    let mut mid = n;
-    while low <= high {
-        mid = (high + low) / 2;
-        if n < mid * mid * mid {
-            high = mid - 1;
-        } else if n == mid * mid * mid {
-            return mid;
-        } else {
-            low = mid + 1;
-        }
-    }
-    return 0;
-}
-
-#[cfg(test)]
-mod get_box_size_tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
-
-    #[test]
-    fn test_get_box_size_1() {
-        let mut atoms = Vec::new();
-        atoms.push(xyzio::Atom {
-            element: String::from("Fe"),
-            x: 4.0 * LATTICE_CONST,
-            y: 6.0 * LATTICE_CONST,
-            z: 8.0 * LATTICE_CONST,
-        });
-        atoms.push(xyzio::Atom {
-            element: String::from("Fe"),
-            x: 2.0 * LATTICE_CONST,
-            y: 1.0 * LATTICE_CONST,
-            z: 9.0 * LATTICE_CONST,
-        });
-        // get lattice size in each dimension
-        let sizes = auto_get_box_size(&atoms);
-        assert_eq!(sizes.0, 2 * 2);
-        assert_eq!(sizes.1, 5);
-        assert_eq!(sizes.2, 1);
-    }
-}
 
 #[cfg(test)]
 mod voronoy_tests {
@@ -325,20 +155,5 @@ mod voronoy_tests {
     fn test_voronoy() {
         assert_eq!(voronoy(1.377608, 1.501391, 1.471441), (1, 0, 0));
         assert_eq!(voronoy(2.772588, 0.056315, -0.044443), (2, 0, 0));
-    }
-}
-
-#[cfg(test)]
-mod cube_root_tests {
-    use super::*;
-
-    #[test]
-    fn test_cube_root() {
-        assert_eq!(cube_root(1), 1);
-        assert_eq!(cube_root(8), 2);
-        assert_eq!(cube_root(27), 3);
-        assert_eq!(cube_root(64), 4);
-        assert_eq!(cube_root(65), 0);
-        assert_eq!(cube_root(125), 5);
     }
 }

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -47,6 +47,11 @@ subcommands:
                 multiple: true
                 help: Sets the filename of input files
                 takes_value: true
+          - verbose:
+                short: v
+                long: verbose
+                help: show verbose log
+                takes_value: false
           - input-from-minio:
               short: M
               long: input-from-minio

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -57,6 +57,16 @@ subcommands:
               long: input-from-minio
               help: Read input files from minio or aws s3 server
               takes_value: false
+          - box-start:
+                short: S
+                long: box-start
+                multiple: true
+                help: start position of simulation box for construction a perfect lattice box (default auto)
+                takes_value: true
+                value_names:
+                  - x
+                  - y
+                  - z
           - box-size:
                 short: b
                 long: box-size

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -52,6 +52,16 @@ subcommands:
               long: input-from-minio
               help: Read input files from minio or aws s3 server
               takes_value: false
+          - box-size:
+                short: b
+                long: box-size
+                multiple: true
+                help: simulation box size. Use auto detection if not specified.
+                takes_value: true
+                value_names:
+                  - x
+                  - y
+                  - z
           - output:
                 short: o
                 long: output

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,8 +91,8 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         }
     }
     let mut box_config = ans::box_config::BoxConfig {
-        box_size,
-        box_size_: (0,0,0)
+        input_box_size: box_size,
+        box_size_: (0, 0, 0),
     };
 
     let mut verbose_log: bool = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,11 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         box_size,
     };
 
+    let mut verbose_log: bool = false;
+    if matches.is_present("verbose") {
+        verbose_log = true;
+    }
+
     let mut input_from_minio: bool = false;
     if matches.is_present("input-from-minio") {
         println!("Now we will read input file from minio or AWS s3");
@@ -104,14 +109,16 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         println!("no matching input files");
         return;
     } else if input_files.len() == 1 {
-        ans::analysis::voronoy_ans_wrapper(input_files[0], output, input_from_minio, &box_config)
+        ans::analysis::voronoy_ans_wrapper(input_files[0], output, input_from_minio,
+                                           &box_config, verbose_log)
     } else {
         for input_file in input_files {
             let input_path = Path::new(input_file);
             println!("analysing file {}", input_file);
             let output_suffix = input_path.file_name().unwrap().to_str().unwrap();
             let output_file_path = format!("{}.{}", output, output_suffix);
-            ans::analysis::voronoy_ans_wrapper(input_file, output_file_path.as_str(), input_from_minio, &box_config);
+            ans::analysis::voronoy_ans_wrapper(input_file, output_file_path.as_str(),
+                                               input_from_minio, &box_config, verbose_log);
             println!("file {} analysis, saved at {}", input_file, output_file_path.as_str());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,16 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         }
     }
 
+    let mut box_size: Vec<u64> = Vec::new();
+    if matches.is_present("box-size") {
+        for l_size in matches.values_of_t::<u64>("box-size").unwrap() {
+            box_size.push(l_size);
+        }
+    }
+    let box_config = ans::analysis::BoxConfig {
+        box_size,
+    };
+
     let mut input_from_minio: bool = false;
     if matches.is_present("input-from-minio") {
         println!("Now we will read input file from minio or AWS s3");
@@ -94,14 +104,14 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         println!("no matching input files");
         return;
     } else if input_files.len() == 1 {
-        ans::voronoy::voronoy_ans_wrapper(input_files[0], output, input_from_minio)
+        ans::analysis::voronoy_ans_wrapper(input_files[0], output, input_from_minio, &box_config)
     } else {
         for input_file in input_files {
             let input_path = Path::new(input_file);
             println!("analysing file {}", input_file);
             let output_suffix = input_path.file_name().unwrap().to_str().unwrap();
             let output_file_path = format!("{}.{}", output, output_suffix);
-            ans::voronoy::voronoy_ans_wrapper(input_file, output_file_path.as_str(), input_from_minio);
+            ans::analysis::voronoy_ans_wrapper(input_file, output_file_path.as_str(), input_from_minio, &box_config);
             println!("file {} analysis, saved at {}", input_file, output_file_path.as_str());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,8 +90,9 @@ fn parse_ans(matches: &&clap::ArgMatches) {
             box_size.push(l_size);
         }
     }
-    let box_config = ans::analysis::BoxConfig {
+    let mut box_config = ans::box_config::BoxConfig {
         box_size,
+        box_size_: (0,0,0)
     };
 
     let mut verbose_log: bool = false;
@@ -109,16 +110,16 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         println!("no matching input files");
         return;
     } else if input_files.len() == 1 {
-        ans::analysis::voronoy_ans_wrapper(input_files[0], output, input_from_minio,
-                                           &box_config, verbose_log)
+        ans::analysis::analysis_wrapper(input_files[0], output, input_from_minio,
+                                        &mut box_config, verbose_log)
     } else {
         for input_file in input_files {
             let input_path = Path::new(input_file);
             println!("analysing file {}", input_file);
             let output_suffix = input_path.file_name().unwrap().to_str().unwrap();
             let output_file_path = format!("{}.{}", output, output_suffix);
-            ans::analysis::voronoy_ans_wrapper(input_file, output_file_path.as_str(),
-                                               input_from_minio, &box_config, verbose_log);
+            ans::analysis::analysis_wrapper(input_file, output_file_path.as_str(),
+                                               input_from_minio, &mut box_config, verbose_log);
             println!("file {} analysis, saved at {}", input_file, output_file_path.as_str());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,12 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         }
     }
 
+    let mut box_start: Vec<ans::voronoy::Float> = Vec::new();
+    if matches.is_present("box-start") {
+        for start in matches.values_of_t::<ans::voronoy::Float>("box-start").unwrap() {
+            box_start.push(start);
+        }
+    }
     let mut box_size: Vec<u64> = Vec::new();
     if matches.is_present("box-size") {
         for l_size in matches.values_of_t::<u64>("box-size").unwrap() {
@@ -91,8 +97,10 @@ fn parse_ans(matches: &&clap::ArgMatches) {
         }
     }
     let mut box_config = ans::box_config::BoxConfig {
+        input_box_start: box_start,
         input_box_size: box_size,
         box_size_: (0, 0, 0),
+        box_start: (0.0, 0.0, 0.0),
     };
 
     let mut verbose_log: bool = false;


### PR DESCRIPTION
Now we can specific box size and box starting position of simulation while performing analysis.
The input box config(box size and box starting position) can be set in cli by `--box-size` and `--box-start`.