### PR TITLE
stylet: correct all building warnings on rust side (unused imports, unused variables/types/mut, snake_case, etc.)

### DIFF
--- a/src/ans/libminio_rw.rs
+++ b/src/ans/libminio_rw.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(dead_code)]
 
 include!(concat!(env!("OUT_DIR"), "/minio_rw_bindings.rs"));

--- a/src/ans/voronoy.rs
+++ b/src/ans/voronoy.rs
@@ -106,7 +106,7 @@ fn do_analysis(writer: &mut BufWriter<File>, (box_x_size, box_y_size, _): (usize
     // each item in this tuple: lattice index, atom array index
     // and draft(means this lattice is not written to file before).
     let mut pre_global_atom_index_data: (Inx, usize, bool) = (-1, 0, false);
-    let mut indexes_i: usize = 0;
+
     // iterate all lattice point to search vacancies and interstitials
     for (lat_index, atom_index) in global_atom_indexes {
         if lat_index == pre_global_atom_index_data.0 {
@@ -134,7 +134,6 @@ fn do_analysis(writer: &mut BufWriter<File>, (box_x_size, box_y_size, _): (usize
             }
             pre_global_atom_index_data = (lat_index, atom_index, true);
         }
-        indexes_i += 1;
     }
 }
 

--- a/src/ans/voronoy.rs
+++ b/src/ans/voronoy.rs
@@ -2,7 +2,6 @@ use std::{f32};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
-use std::collections::BTreeMap;
 use rayon::prelude::*;
 use xyzio::Atom;
 

--- a/src/diff/diff.rs
+++ b/src/diff/diff.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::cmp::Ordering;
 use crate::xyz::xyz_reader::{Reader, Snapshot};
 use crate::xyz::particle::Particle;
 

--- a/src/diff/diff.rs
+++ b/src/diff/diff.rs
@@ -3,8 +3,8 @@ use crate::xyz::xyz_reader::{Reader, Snapshot};
 use crate::xyz::particle::Particle;
 
 pub fn diff_wrapper(file1: &str, file2: &str, error_limit: f64, periodic_checking: bool, box_measured_size: (f64, f64, f64)) {
-    let mut input_1 = File::open(file1).unwrap();
-    let mut input_2 = File::open(file2).unwrap();
+    let input_1 = File::open(file1).unwrap();
+    let input_2 = File::open(file2).unwrap();
 
     let mut reader1 = Reader::new(input_1);
     let mut reader2 = Reader::new(input_2);
@@ -14,7 +14,7 @@ pub fn diff_wrapper(file1: &str, file2: &str, error_limit: f64, periodic_checkin
         Err(e) => {
             panic!("read input xyz file error: {:?}", e);
         }
-        Ok(ref snapshot) => {}
+        Ok(ref _snapshot) => {}
     }
 
     let snapshot_result_2 = reader2.read_snapshot();
@@ -22,7 +22,7 @@ pub fn diff_wrapper(file1: &str, file2: &str, error_limit: f64, periodic_checkin
         Err(e) => {
             panic!("read input xyz file error: {:?}", e);
         }
-        Ok(ref snapshot) => {}
+        Ok(ref _snapshot) => {}
     }
 
     diff(&mut snapshot_result_1.unwrap(), &mut snapshot_result_2.unwrap(), error_limit, periodic_checking, box_measured_size);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,19 +6,19 @@ use std::{fmt, error};
 #[repr(C)]
 pub struct OneAtomType {
     // u64
-    pub  AtomId: libc::c_ulong,
+    pub atom_id: libc::c_ulong,
     // fixme matching size_t in C side.
-    pub  Step: libc::c_ulong,
-    pub  AtomType: libc::c_int,
-    pub  InterType: libc::c_short,
+    pub step: libc::c_ulong,
+    pub atom_type: libc::c_int,
+    pub inter_type: libc::c_short,
     // double 64
-    pub  Location: [libc::c_double; 3],
-    pub  Velocity: [libc::c_double; 3],
+    pub location: [libc::c_double; 3],
+    pub velocity: [libc::c_double; 3],
 }
 
 impl OneAtomType {
     pub fn get_name_by_ele_name(&self) -> &'static str {
-        match self.AtomType {
+        match self.atom_type {
             -1 => "V",
             0 => "Fe",
             1 => "Cu",

--- a/src/text_parser.rs
+++ b/src/text_parser.rs
@@ -21,9 +21,9 @@ writer.write_all(b"test\n");
 impl ParseProgress for TextParser {
     fn on_atom_read(&mut self, atom: &OneAtomType) -> i32 {
         let fmt_string = format!("{} \t{} \t{} \t{} \t{:.6} \t{:.6} \t{:.6}  \t{:.6} \t{:.6} \t{:.6}\n",
-                                 atom.AtomId, atom.Step, atom.get_name_by_ele_name(), atom.InterType,
-                                 atom.Location[0], atom.Location[1], atom.Location[2],
-                                 atom.Velocity[0], atom.Velocity[1], atom.Velocity[2]);
+                                 atom.atom_id, atom.step, atom.get_name_by_ele_name(), atom.inter_type,
+                                 atom.location[0], atom.location[1], atom.location[2],
+                                 atom.velocity[0], atom.velocity[1], atom.velocity[2]);
         self.output.write(fmt_string.as_bytes()).unwrap();
         return 1 as i32;
     }

--- a/src/xyz/particle.rs
+++ b/src/xyz/particle.rs
@@ -1,16 +1,10 @@
 /**
- * this file is copied from xyzio package,
- * but add `rayon` parallel support for reading file
+ * Add support for parsing id, position and velocity in line string of xyz file.
  */
 
-use std::{io, fmt};
-use std::io::prelude::BufRead;
 use std::iter::Iterator;
 
 use std::str::FromStr;
-use std::num::ParseFloatError;
-use std::fmt::Display;
-use rayon::prelude::*;
 use xyzio::Error;
 
 type Real = f64;

--- a/src/xyz_parser.rs
+++ b/src/xyz_parser.rs
@@ -17,7 +17,7 @@ impl ParseProgress for XYZParser {
     fn on_atom_read(&mut self, atom: &OneAtomType) -> i32 {
         let fmt_string = format!("{} \t{:.6} \t{:.6} \t{:.6}\n",
                                  atom.get_name_by_ele_name(),
-                                 atom.Location[0], atom.Location[1], atom.Location[2]);
+                                 atom.location[0], atom.location[1], atom.location[2]);
         self.output.write(fmt_string.as_bytes()).unwrap();
         self.atom_count += 1;
         return 1 as i32;


### PR DESCRIPTION
We corrected/removed all building warnings on rust side, including unused imports, unused variables/types/mut, snake_case, etc.

Note: there are still some building warnings in C code (see Github Action of this PR).