### PR TITLE
feat(analysis): cargo feature "minio-analysis" to enable/disable "reading from minio for analyzing"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ byte_struct = "0.6.1"
 [build-dependencies]
 cc = "1.0"
 bindgen = "0.56.0"
+
+[features]
+default = []
+minio-analysis = []

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,13 @@ fn main() {
         .cpp(false)
         .compile("libconv.a");
 
+    if cfg!(feature = "minio-analysis") {
+        gen_minio_rw_api();
+    }
+    gen_conversion_api();
+}
+
+fn gen_minio_rw_api() {
     println!("cargo:rerun-if-changed=src/ans/minio/minio-rw.go");
 
     // run `go build --buildmode=c-archive -o /path/to/save/libminio_rw.a`
@@ -41,8 +48,6 @@ fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings.write_to_file(out_path.join("minio_rw_bindings.rs"))
         .expect("Couldn't write bindings!");
-
-    gen_conversion_api();
 }
 
 fn gen_conversion_api() {

--- a/src/ans/analysis.rs
+++ b/src/ans/analysis.rs
@@ -5,8 +5,7 @@ use std::fs::File;
 use std::io::Read;
 use std::io;
 
-use crate::ans::minio_input::voronoy_ans_minio;
-use crate::ans::libminio_rw;
+use crate::ans::minio_input;
 use crate::ans::box_config::{BoxConfig, config_simulation_box};
 use crate::ans::voronoy::do_analysis_wrapper;
 use crate::xyz::xyz_reader::Reader;
@@ -16,12 +15,10 @@ use crate::xyz::xyz_reader::Reader;
 // select to read from minio or local file system based in input config.
 pub fn analysis_wrapper(xyzfile: &str, output: &str, input_from_minio: bool, box_config: &mut BoxConfig, verbose: bool) {
     if input_from_minio {
-        let (mut data, data_ptr) = voronoy_ans_minio(xyzfile);
-        if data.len() != 0 {
+        let (ok, mut data, data_ptr) = minio_input::voronoy_ans_minio(xyzfile);
+        if ok {
             let on_data_loaded = |atoms_size: usize| {
-                unsafe {
-                    libminio_rw::ReleaseMinioFile(data_ptr);
-                };
+                minio_input::release_minio_file(data_ptr);
                 println!("atom size is {}", atoms_size);
             };
             read_atoms_and_analysis(&mut data, output, on_data_loaded, box_config, verbose);

--- a/src/ans/minio_input.rs
+++ b/src/ans/minio_input.rs
@@ -1,7 +1,29 @@
+#[cfg(feature = "minio-analysis")]
 use crate::ans::libminio_rw;
 use std::ffi::{CStr, CString};
+use std::ptr::{null_mut, null};
 
-pub fn voronoy_ans_minio(xyzfile: &str) -> (&[u8], *mut libc::c_char) {
+#[cfg(not(feature = "minio-analysis"))]
+pub fn voronoy_ans_minio(_xyz_file: &str) -> (bool, &[u8], *mut libc::c_char) {
+    println!("The feature of reading files from minio sever for analysis is disabled");
+    // let data = String::from("Hello, world!").as_bytes();
+    return (false, _xyz_file.as_bytes(), null_mut());
+}
+
+#[cfg(not(feature = "minio-analysis"))]
+pub fn release_minio_file(data_ptr: *mut libc::c_char) {
+    return;
+}
+
+#[cfg(feature = "minio-analysis")]
+pub fn release_minio_file(data_ptr: *mut libc::c_char) {
+    unsafe {
+        libminio_rw::ReleaseMinioFile(data_ptr);
+    }
+}
+
+#[cfg(feature = "minio-analysis")]
+pub fn voronoy_ans_minio(xyzfile: &str) -> (bool, &[u8], *mut libc::c_char) {
     let file = CString::new(xyzfile).unwrap();
     let status: libminio_rw::ReadMinioFile_return = unsafe {
         libminio_rw::ReadMinioFile(file.as_ptr() as *mut libc::c_char)
@@ -10,7 +32,7 @@ pub fn voronoy_ans_minio(xyzfile: &str) -> (&[u8], *mut libc::c_char) {
     let err_str: &str = unsafe { CStr::from_ptr(status.r2) }.to_str().unwrap();
     if err_str != "" {
         println!("error: {}", err_str);
-        return (&[], status.r0);
+        return (false, &[], status.r0);
     }
 
     let data_size: u64 = status.r1 as u64; // libc::c_ulong (in fact, it is just u64) to u64
@@ -20,5 +42,5 @@ pub fn voronoy_ans_minio(xyzfile: &str) -> (&[u8], *mut libc::c_char) {
 
     assert_eq!(data.len() as u64, data_size);
     println!("data size: {}", data_size);
-    return (data, status.r0);
+    return (data.len() != 0, data, status.r0);
 }

--- a/src/ans/mod.rs
+++ b/src/ans/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod voronoy;
 pub(crate) mod analysis;
 pub(crate) mod box_config;
+#[cfg(feature = "minio-analysis")]
 mod libminio_rw;
 mod minio_input;


### PR DESCRIPTION
we add a new feature "minio-analysis" to "features" section of Cargo.toml file, which can be used
to enable or disable the ability of "reading files from minio for analyzing"